### PR TITLE
Ethan loo

### DIFF
--- a/dashboard/src/components/blocks/editor-00/toolbar.tsx
+++ b/dashboard/src/components/blocks/editor-00/toolbar.tsx
@@ -104,12 +104,12 @@ const FONT_FAMILIES = [
 ]
 
 const FONT_SIZES = [
-  "12px",
-  "14px",
-  "16px",
-  "18px",
-  "24px",
-  "32px",
+  { label: "Default", value: "default" },
+  { label: "0.75rem", value: "0.75rem" },
+  { label: "0.875rem", value: "0.875rem" },
+  { label: "1.125rem", value: "1.125rem" },
+  { label: "1.5rem", value: "1.5rem" },
+  { label: "2rem", value: "2rem" },
 ]
 
 const BLOCK_OPTIONS: Array<{ label: string; value: BlockType; icon?: ReactNode }> = [
@@ -149,6 +149,27 @@ function normalizeColor(color: string): string {
   }
 
   return "#000000"
+}
+
+function normalizeFontSize(size: string): string {
+  const normalized = size.trim().toLowerCase()
+  if (normalized === "" || normalized === "16px" || normalized === "1rem") {
+    return "default"
+  }
+
+  const pxToRem: Record<string, string> = {
+    "12px": "0.75rem",
+    "14px": "0.875rem",
+    "18px": "1.125rem",
+    "24px": "1.5rem",
+    "32px": "2rem",
+  }
+
+  if (pxToRem[normalized]) {
+    return pxToRem[normalized]
+  }
+
+  return FONT_SIZES.some((option) => option.value === normalized) ? normalized : "default"
 }
 
 function ToolbarButton({
@@ -214,7 +235,7 @@ export function ToolbarPlugin() {
   const [blockType, setBlockType] = useState<BlockType>("paragraph")
   const [elementFormat, setElementFormat] = useState<ElementFormat>("left")
   const [fontFamily, setFontFamily] = useState<string>("default")
-  const [fontSize, setFontSize] = useState<string>("16px")
+  const [fontSize, setFontSize] = useState<string>("default")
   const [fontColor, setFontColor] = useState<string>("#000000")
   const [isLinkSelected, setIsLinkSelected] = useState(false)
   const [canUndo, setCanUndo] = useState(false)
@@ -273,9 +294,8 @@ export function ToolbarPlugin() {
       : "default"
     setFontFamily(normalizedFamily)
 
-    const currentFontSize = $getSelectionStyleValueForProperty(selection, "font-size", "16px")
-    const normalizedSize = FONT_SIZES.includes(currentFontSize) ? currentFontSize : "16px"
-    setFontSize(normalizedSize)
+    const currentFontSize = $getSelectionStyleValueForProperty(selection, "font-size", "")
+    setFontSize(normalizeFontSize(currentFontSize))
 
     let node: TextNode | ElementNode | null = anchorNode
     let isLink = false
@@ -551,16 +571,16 @@ export function ToolbarPlugin() {
         value={fontSize}
         onValueChange={(value) => {
           setFontSize(value)
-          applyStyleText({ "font-size": value })
+          applyStyleText({ "font-size": value === "default" ? "" : value })
         }}
       >
         <SelectTrigger className="w-24">
           <SelectValue placeholder="Font size" />
         </SelectTrigger>
         <SelectContent>
-          {FONT_SIZES.map((size) => (
-            <SelectItem key={size} value={size}>
-              {size}
+          {FONT_SIZES.map(({ label, value }) => (
+            <SelectItem key={value} value={value}>
+              {label}
             </SelectItem>
           ))}
         </SelectContent>

--- a/dashboard/src/features/articles/article-creation/ArticleForm.tsx
+++ b/dashboard/src/features/articles/article-creation/ArticleForm.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
-import { $getRoot } from "lexical";
+import {
+  $getRoot,
+  IS_BOLD,
+  IS_CODE,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+  IS_UNDERLINE,
+} from "lexical";
 
 import { Editor } from "@/components/blocks/editor-00/editor";
 import { Button } from "@/components/ui/button";
@@ -192,32 +201,138 @@ export default function ArticleForm({
   // Enhanced Lexical to HTML conversion that preserves all formatting
   const convertLexicalToHtml = (editorState: SerializedEditorState): string => {
     try {
+      const numberToRem = (num: number) =>
+        `${num.toFixed(4).replace(/\.?0+$/, "")}rem`;
+
+      const normalizeFontSizeStyle = (value: string): string => {
+        const normalized = value.trim().toLowerCase();
+        if (!normalized) return "";
+
+        const pxMatch = normalized.match(/^(\d+(?:\.\d+)?)px$/);
+        if (pxMatch) {
+          const rem = Number(pxMatch[1]) / 16;
+          if (Math.abs(rem - 1) < 0.001) return "";
+          return numberToRem(rem);
+        }
+
+        const remMatch = normalized.match(/^(\d+(?:\.\d+)?)rem$/);
+        if (remMatch) {
+          const rem = Number(remMatch[1]);
+          if (Math.abs(rem - 1) < 0.001) return "";
+          return numberToRem(rem);
+        }
+
+        return value.trim();
+      };
+
+      const normalizeInlineStyle = (style: string): string => {
+        const declarations = style
+          .split(";")
+          .map((part) => part.trim())
+          .filter(Boolean);
+
+        const normalizedDeclarations = declarations
+          .map((declaration) => {
+            const [rawProp, ...rest] = declaration.split(":");
+            if (!rawProp || rest.length === 0) return "";
+
+            const prop = rawProp.trim().toLowerCase();
+            const value = rest.join(":").trim();
+            if (!value) return "";
+
+            if (prop === "font-size") {
+              const normalizedFontSize = normalizeFontSizeStyle(value);
+              return normalizedFontSize ? `font-size: ${normalizedFontSize}` : "";
+            }
+
+            return `${prop}: ${value}`;
+          })
+          .filter(Boolean);
+
+        return normalizedDeclarations.join("; ");
+      };
+
+      const resolveAlignment = (format: unknown): string | undefined => {
+        const allowed = new Set(["left", "center", "right", "justify", "start", "end"]);
+        if (typeof format === "string") {
+          const normalized = format.trim().toLowerCase();
+          return allowed.has(normalized) ? normalized : undefined;
+        }
+
+        if (typeof format === "number") {
+          const alignMap: Record<number, string> = {
+            1: "left",
+            2: "center",
+            3: "right",
+            4: "justify",
+            5: "start",
+            6: "end",
+          };
+          return alignMap[format];
+        }
+
+        return undefined;
+      };
+
+      const buildBlockStyleAttr = (node: any): string => {
+        const styles: string[] = [];
+        const align = resolveAlignment(node?.format);
+        if (align) {
+          styles.push(`text-align: ${align}`);
+        }
+
+        if (typeof node?.style === "string") {
+          const normalized = normalizeInlineStyle(node.style);
+          if (normalized) {
+            styles.push(normalized);
+          }
+        }
+
+        if (styles.length === 0) {
+          return "";
+        }
+
+        return ` style="${styles.join("; ").replace(/"/g, "&quot;")}"`;
+      };
+
+      const escapeHtml = (value: string) =>
+        value
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+
       const extractFormattedTextFromNode = (node: any): string => {
         // Handle text nodes with formatting
         if (node.type === 'text') {
-          let textContent = node.text || '';
+          let textContent = escapeHtml(node.text || '');
+          const nodeStyle = typeof node.style === "string" ? normalizeInlineStyle(node.style) : "";
           
           // Apply text formatting
-          if (node.format & 1) { // Bold
+          if (node.format & IS_BOLD) { // Bold
             textContent = `<strong>${textContent}</strong>`;
           }
-          if (node.format & 2) { // Italic
+          if (node.format & IS_ITALIC) { // Italic
             textContent = `<em>${textContent}</em>`;
           }
-          if (node.format & 4) { // Underline
+          if (node.format & IS_UNDERLINE) { // Underline
             textContent = `<u>${textContent}</u>`;
           }
-          if (node.format & 8) { // Strikethrough
+          if (node.format & IS_STRIKETHROUGH) { // Strikethrough
             textContent = `<s>${textContent}</s>`;
           }
-          if (node.format & 16) { // Code
+          if (node.format & IS_CODE) { // Code
             textContent = `<code>${textContent}</code>`;
           }
-          if (node.format & 32) { // Subscript
+          if (node.format & IS_SUBSCRIPT) { // Subscript
             textContent = `<sub>${textContent}</sub>`;
           }
-          if (node.format & 64) { // Superscript
+          if (node.format & IS_SUPERSCRIPT) { // Superscript
             textContent = `<sup>${textContent}</sup>`;
+          }
+
+          // Preserve inline styles set from toolbar (font-size/font-family/color).
+          if (nodeStyle) {
+            textContent = `<span style="${nodeStyle.replace(/"/g, "&quot;")}">${textContent}</span>`;
           }
           
           return textContent;
@@ -227,16 +342,8 @@ export default function ArticleForm({
         if (node.type === 'paragraph') {
           if (node.children && Array.isArray(node.children)) {
             const paragraphContent = node.children.map(extractFormattedTextFromNode).join('');
-            
-            // Handle text alignment
-            const format = node.format || 0;
-            let alignClass = '';
-            if (format & 1) alignClass = ' style="text-align: left;"';
-            if (format & 2) alignClass = ' style="text-align: center;"';
-            if (format & 3) alignClass = ' style="text-align: right;"';
-            if (format & 4) alignClass = ' style="text-align: justify;"';
-            
-            return paragraphContent ? `<p${alignClass}>${paragraphContent}</p>` : '<p><br></p>';
+            const styleAttr = buildBlockStyleAttr(node);
+            return paragraphContent ? `<p${styleAttr}>${paragraphContent}</p>` : `<p${styleAttr}><br></p>`;
           }
           return '<p><br></p>';
         }
@@ -246,7 +353,8 @@ export default function ArticleForm({
           if (node.children && Array.isArray(node.children)) {
             const headingContent = node.children.map(extractFormattedTextFromNode).join('');
             const tag = node.tag || 'h1';
-            return `<${tag}>${headingContent}</${tag}>`;
+            const styleAttr = buildBlockStyleAttr(node);
+            return `<${tag}${styleAttr}>${headingContent}</${tag}>`;
           }
           return '';
         }
@@ -256,7 +364,8 @@ export default function ArticleForm({
           if (node.children && Array.isArray(node.children)) {
             const listItems = node.children.map(extractFormattedTextFromNode).join('');
             const listTag = node.listType === 'bullet' ? 'ul' : 'ol';
-            return `<${listTag}>${listItems}</${listTag}>`;
+            const styleAttr = buildBlockStyleAttr(node);
+            return `<${listTag}${styleAttr}>${listItems}</${listTag}>`;
           }
           return '';
         }
@@ -265,7 +374,8 @@ export default function ArticleForm({
         if (node.type === 'listitem') {
           if (node.children && Array.isArray(node.children)) {
             const itemContent = node.children.map(extractFormattedTextFromNode).join('');
-            return `<li>${itemContent}</li>`;
+            const styleAttr = buildBlockStyleAttr(node);
+            return `<li${styleAttr}>${itemContent}</li>`;
           }
           return '<li></li>';
         }
@@ -274,7 +384,8 @@ export default function ArticleForm({
         if (node.type === 'quote') {
           if (node.children && Array.isArray(node.children)) {
             const quoteContent = node.children.map(extractFormattedTextFromNode).join('');
-            return `<blockquote>${quoteContent}</blockquote>`;
+            const styleAttr = buildBlockStyleAttr(node);
+            return `<blockquote${styleAttr}>${quoteContent}</blockquote>`;
           }
           return '<blockquote></blockquote>';
         }
@@ -283,7 +394,8 @@ export default function ArticleForm({
         if (node.type === 'code') {
           if (node.children && Array.isArray(node.children)) {
             const codeContent = node.children.map(extractFormattedTextFromNode).join('');
-            return `<pre><code>${codeContent}</code></pre>`;
+            const styleAttr = buildBlockStyleAttr(node);
+            return `<pre${styleAttr}><code>${codeContent}</code></pre>`;
           }
           return '<pre><code></code></pre>';
         }
@@ -299,7 +411,7 @@ export default function ArticleForm({
             const linkContent = node.children.map(extractFormattedTextFromNode).join('');
             const url = node.url || '#';
             const title = node.title ? ` title="${node.title}"` : '';
-            return `<a href="${url}"${title}>${linkContent}</a>`;
+            return `<a href="${url}"${title} target="_blank">${linkContent}</a>`;
           }
           return '';
         }

--- a/frontend/src/components/ArticleBlock.tsx
+++ b/frontend/src/components/ArticleBlock.tsx
@@ -46,7 +46,7 @@ function ArticleBlock({ article, height }: ArticleBlockProps) {
 
             <div className="relative z-10 w-full pointer-events-none">
                 <h3
-                    className="title text-white font-bold text-2xl/7 mb-2 overflow-hidden"
+                    className="title text-white font-bold text-[clamp(1rem,0.8rem+1vw,1.5rem)]/7 mb-2 overflow-hidden"
                     style={{
                         display: '-webkit-box',
                         WebkitLineClamp: 3,

--- a/frontend/src/components/ArticleBlock.tsx
+++ b/frontend/src/components/ArticleBlock.tsx
@@ -46,7 +46,7 @@ function ArticleBlock({ article, height }: ArticleBlockProps) {
 
             <div className="relative z-10 w-full pointer-events-none">
                 <h3
-                    className="title text-white font-bold text-[clamp(1rem,0.8rem+1vw,1.5rem)]/7 mb-2 overflow-hidden"
+                    className="title text-white font-bold text-2xl/7 mb-2 overflow-hidden"
                     style={{
                         display: '-webkit-box',
                         WebkitLineClamp: 3,


### PR DESCRIPTION
This pull request enhances font size handling and formatting consistency in the editor toolbar and article HTML export. The most significant changes include standardizing font size options, normalizing font size values throughout the editor and export process, and improving the preservation of formatting and styles in the HTML output.

**Editor Toolbar and Font Size Handling:**

* Changed `FONT_SIZES` in `toolbar.tsx` to use objects with `label` and `value` (in rem units), and updated the default font size handling to use `"default"` instead of `"16px"` [[1]](diffhunk://#diff-156e3c72712f7454dfe211dc763a80dfaef6687310bfe40949ff6ab436d800a3L107-R112) [[2]](diffhunk://#diff-156e3c72712f7454dfe211dc763a80dfaef6687310bfe40949ff6ab436d800a3L217-R238).
* Added a `normalizeFontSize` utility to ensure font size values are consistently normalized to rem units or default, and updated the toolbar logic to use this normalization when reading and applying font sizes [[1]](diffhunk://#diff-156e3c72712f7454dfe211dc763a80dfaef6687310bfe40949ff6ab436d800a3R154-R174) [[2]](diffhunk://#diff-156e3c72712f7454dfe211dc763a80dfaef6687310bfe40949ff6ab436d800a3L276-R298).
* Updated the font size select dropdown to use labels and values from the new `FONT_SIZES` structure, and to apply an empty string for the default font size.

**Article HTML Export Improvements:**

* Refactored the Lexical-to-HTML export logic in `ArticleForm.tsx` to:
  - Normalize all font-size styles to rem units and omit the style if equivalent to the default.
  - Preserve all inline styles (font-size, font-family, color) and formatting (bold, italic, underline, etc.) in exported HTML, including for block-level elements like paragraphs, headings, lists, and quotes [[1]](diffhunk://#diff-7260bc3b43c35b821ce6078ddd35b56d243157522499132af03cf3e27133d84cR204-R346) [[2]](diffhunk://#diff-7260bc3b43c35b821ce6078ddd35b56d243157522499132af03cf3e27133d84cL249-R357) [[3]](diffhunk://#diff-7260bc3b43c35b821ce6078ddd35b56d243157522499132af03cf3e27133d84cL259-R368) [[4]](diffhunk://#diff-7260bc3b43c35b821ce6078ddd35b56d243157522499132af03cf3e27133d84cL268-R378) [[5]](diffhunk://#diff-7260bc3b43c35b821ce6078ddd35b56d243157522499132af03cf3e27133d84cL277-R388) [[6]](diffhunk://#diff-7260bc3b43c35b821ce6078ddd35b56d243157522499132af03cf3e27133d84cL286-R398).
  - Ensure links open in a new tab by adding `target="_blank"` to exported anchor tags.

**Formatting and Code Quality:**

* Replaced hardcoded format bitmasks in the export logic with named constants from Lexical for improved readability and maintainability [[1]](diffhunk://#diff-7260bc3b43c35b821ce6078ddd35b56d243157522499132af03cf3e27133d84cL2-R11) [[2]](diffhunk://#diff-7260bc3b43c35b821ce6078ddd35b56d243157522499132af03cf3e27133d84cR204-R346).