### PR TITLE
wrote more verbose loggin for github action

### DIFF
--- a/.github/workflows/keep-render-warm.yml
+++ b/.github/workflows/keep-render-warm.yml
@@ -19,4 +19,18 @@ jobs:
           fi
 
           echo "Pinging $HEALTHCHECK_URL"
-          curl --fail --show-error --silent --max-time 20 --retry 2 "$HEALTHCHECK_URL"
+          RESPONSE_FILE="$(mktemp)"
+          STATUS_CODE="$(curl --silent --show-error --location --max-time 20 --retry 2 \
+            --output "$RESPONSE_FILE" --write-out "%{http_code}" "$HEALTHCHECK_URL")"
+
+          echo "Triggered $HEALTHCHECK_URL with status $STATUS_CODE"
+          echo "Response preview:"
+          head -c 500 "$RESPONSE_FILE" || true
+          echo
+
+          if [ "$STATUS_CODE" -ge 200 ] && [ "$STATUS_CODE" -lt 300 ]; then
+            echo "Health check succeeded with 2xx status."
+          else
+            echo "Health check failed with non-2xx status."
+            exit 1
+          fi


### PR DESCRIPTION
This pull request enhances the health check step in the `.github/workflows/keep-render-warm.yml` workflow. The changes improve error handling and debugging by capturing and displaying the HTTP status code and a preview of the response.

**Improvements to health check and logging:**

* Modified the health check command to capture the HTTP status code and save the response body to a temporary file for easier debugging. The workflow now outputs the status code and a preview of the response, then explicitly fails if the status code is not in the 2xx range.