### PR TITLE
fix: hides just in header for articles older than 5 days

### DIFF
--- a/frontend/src/components/JustIn.tsx
+++ b/frontend/src/components/JustIn.tsx
@@ -38,6 +38,19 @@ function formatTimeSincePublished(publishedAt?: string | Date | null) {
 function JustInBlock({ article }: ArticleProps) {
     const navigate = useNavigate();
     const link = getArticleLink(article);
+    
+    if (article.publishedAt) {
+            const publishedDate = new Date(article.publishedAt);
+            if (!Number.isNaN(publishedDate.getTime())) {
+                const diffInMilliseconds = Date.now() - publishedDate.getTime();
+                const fiveDaysInMilliseconds = 5 * 24 * 60 * 60 * 1000;
+
+                // If article is older than 5 days, render nothing
+                if (diffInMilliseconds > fiveDaysInMilliseconds) {
+                    return null;
+                }
+            }
+        }
 
     return (
         <div className='flex flex-col sm:flex-row gap-4 content-center cursor-pointer' onClick={() => navigate(link)}>


### PR DESCRIPTION
Hides the just in header for articles older than 5 days. 
Tested with test articles (1 day and 7 days). 