### PR TITLE
feat: database for print publications

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ import articleRoutes from './routes/article.routes';
 import categoryRoutes from './routes/category.routes';
 import commentRoutes from './routes/comment.routes';
 import playlistRoutes from './routes/playlist.routes';
+import publicationRoutes from './routes/publication.routes';
 import sliverRoutes from './routes/sliver.routes';
 import subCategoryRoutes from './routes/subCategory.routes';
 import tagRoutes from './routes/tag.routes';
@@ -195,6 +196,7 @@ export function createApp() {
   app.use('/api/users', userRoutes);
   app.use('/api/authors', authorRoutes);
   app.use('/api/playlists', playlistRoutes);
+  app.use('/api/publications', publicationRoutes);
   app.use('/api/slivers', sliverRoutes);
   app.use('/api/comments', commentRoutes);
   app.use('/api/admin/media', mediaRoutes);

--- a/backend/src/controllers/publication.controller.ts
+++ b/backend/src/controllers/publication.controller.ts
@@ -6,7 +6,7 @@
 //
 
 import { Request, Response } from 'express';
-import PrintPublication, { IPrintPublication } from '../models/printpublication';
+import PrintPublication, { IPrintPublication } from '../models/PrintPublication';
 
 // get dates
 export const getPublications = async (req: Request, res: Response): Promise<void> => {

--- a/backend/src/controllers/publication.controller.ts
+++ b/backend/src/controllers/publication.controller.ts
@@ -1,0 +1,36 @@
+//
+//  printPublicationController.ts
+//  
+//
+//  Created by Nha Han Nguyen on 7/1/26.
+//
+
+import { Request, Response } from 'express';
+import PrintPublication, { IPrintPublication } from '../models/printpublication';
+
+// get dates
+export const getPublications = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const publications: IPrintPublication[] = await PrintPublication.find().sort({ publishDate: -1 });
+    res.status(200).json(publications);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch publication dates.' });
+  }
+};
+
+// enter new date
+export const createPublication = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { issueName, issueType, publishDate } = req.body;
+    const newPublication: IPrintPublication = new PrintPublication({
+      issueName,
+      issueType,
+      publishDate
+    });
+    
+    await newPublication.save();
+    res.status(201).json(newPublication);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to create publication date.' });
+  }
+};

--- a/backend/src/controllers/publication.controller.ts
+++ b/backend/src/controllers/publication.controller.ts
@@ -9,7 +9,7 @@ import { Request, Response } from 'express';
 import PrintPublication, { IPrintPublication } from '../models/PrintPublication';
 
 // get dates
-export const getPublications = async (req: Request, res: Response): Promise<void> => {
+export const getPublications = async (_req: Request, res: Response): Promise<void> => {
   try {
     const publications: IPrintPublication[] = await PrintPublication.find().sort({ publishDate: -1 });
     res.status(200).json(publications);

--- a/backend/src/models/PrintPublication.ts
+++ b/backend/src/models/PrintPublication.ts
@@ -1,0 +1,34 @@
+//
+//  PrintPublication.ts
+//  
+//
+//  Created by Nha Han Nguyen on 7/1/26.
+//
+
+import mongoose, { Schema, Document } from 'mongoose';
+
+// interface
+export interface IPrintPublication extends Document {
+  issueName: string;
+  issueType: string;
+  publishDate: Date;
+}
+
+// schema corresponding to the interface
+const PrintPublicationSchema: Schema = new Schema({
+  issueName: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  issueType: {
+    type: String,
+    required: true
+  },
+  publishDate: {
+    type: Date,
+    required: true
+  }
+}, { timestamps: true });
+
+export default mongoose.model<IPrintPublication>('PrintPublication', PrintPublicationSchema);

--- a/backend/src/routes/publication.routes.ts
+++ b/backend/src/routes/publication.routes.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+import { getPublications, createPublication } from '../controllers/publication.controller';
+import { authMiddleware } from '../middleware/auth.middleware';
+import { adminMiddleware } from '../middleware/admin.middleware';
+
+const router = express.Router();
+
+// public to get date
+router.get('/', getPublications);
+
+// only admins can edit publication dates
+router.post('/', authMiddleware, adminMiddleware, createPublication);
+
+export default router;


### PR DESCRIPTION
Added backend database schema and API routes for print publication dates

- Created databased schema with print publication fields
- GET/POST routes added
- POST route is secured (only admins/editors can edit)

Tested both GET and POST locally and verified data insertion in MongoDB