### PR TITLE
feat: displaying upcoming print dates on Submit Ad and About pages

### DIFF
--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import articleService from '../services/articleService';
+import publicationService from '../services/publicationService';
 import { ArticleDocument } from '../types/article';
+import { Publication, formatPublicationDate } from '../utils/dateFormat';
 import { FaFacebook, FaXTwitter, FaInstagram, FaTiktok, FaLinkedin } from "react-icons/fa6";
 import Navbar from "../components/Navbar";
 import Collage from "../components/Collage";
@@ -9,41 +11,43 @@ import Spinner from '../components/Spinner';
 function About() {
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [recentArticles, setRecentArticles] = useState<ArticleDocument[]>([]);
+    const [publications, setPublications] = useState<Publication[]>([]);
 
     useEffect(() => {
-            let isMounted = true;
-            const controller = new AbortController();
-    
-            const loadArticles = async () => {
-                setIsLoading(true);
-    
-                try {
-                    // Services now return unwrapped data directly
-                    const recentArticlesData = await articleService.fetchRecentArticles(7, 'published', controller.signal);
-    
-                    if (!isMounted) {
-                        return;
-                    }
-    
-                    setRecentArticles(recentArticlesData || []);
-                } catch {
-                    if (!isMounted) {
-                        return;
-                    }
-                } finally {
-                    if (isMounted) {
-                        setIsLoading(false);
-                    }
+        let isMounted = true;
+        const controller = new AbortController();
+
+        const loadData = async () => {
+            setIsLoading(true);
+
+            try {
+                // fetching articles and publication dates at the same time
+                const [recentArticlesData, publicationsData] = await Promise.all([
+                    articleService.fetchRecentArticles(7, 'published', controller.signal),
+                    publicationService.getPublications()
+                ]);
+
+                if (!isMounted) return;
+
+                setRecentArticles(recentArticlesData || []);
+                setPublications(publicationsData || []);
+            } catch (err) {
+                if (!isMounted) return;
+                console.error('Error loading About page data:', err);
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
                 }
-            };
-    
-            loadArticles();
-    
-            return () => {
-                isMounted = false;
-                controller.abort();
-            };
-        }, []);
+            }
+        };
+
+        loadData();
+
+        return () => {
+            isMounted = false;
+            controller.abort();
+        };
+    }, []);
 
     if (isLoading) {
         return (
@@ -61,7 +65,7 @@ function About() {
                 <h4 className="font-bold mb-2 text-2xl text-nique-blue">About Us</h4>
             </div>
 
-            <Collage articles={[recentArticles[0], recentArticles[1], recentArticles[2], recentArticles[3], recentArticles[4], recentArticles[5], recentArticles[6]].filter(Boolean) as ArticleDocument[]} /> {/* collection of best pictures you may want to feature */}
+            <Collage articles={[recentArticles[0], recentArticles[1], recentArticles[2], recentArticles[3], recentArticles[4], recentArticles[5], recentArticles[6]].filter(Boolean) as ArticleDocument[]} />
 
             {/* Mission */}
             <div className='grid grid-cols-1 sm:grid-cols-3 max-w-[95%] md:max-w-[80%] m-auto p-5 gap-x-16'>
@@ -80,6 +84,20 @@ function About() {
                     </p>
                 </div>
             </div>
+
+            {/* Upcoming Print Schedule */}
+            {publications.length > 0 && (
+                <div className='max-w-[80%] m-auto p-5'>
+                    <h4 className='text-2xl font-bold text-nique-blue my-6'>Upcoming Print Dates</h4>
+                    <ul className='list-disc ml-8 text-lg'>
+                        {publications.map((pub) => (
+                            <li key={pub._id} className='mt-2'>
+                                {formatPublicationDate(pub)}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
 
             {/* Vision */}
             <div className='max-w-[80%] m-auto p-5'>
@@ -126,44 +144,44 @@ function About() {
             <div className='max-w-[80%] m-auto p-5'>
                 <h4 className='text-2xl font-bold text-nique-blue my-6'>Getting Involved</h4>
                 <p className='text-lg mt-5'>
-                    Interested in writing, photography, sales or design? If so, the Technique has a lot to offer. Our staff is comprised entirely of Tech students interested 
+                    Interested in writing, photography, sales or design? If so, the Technique has a lot to offer. Our staff is comprised entirely of Tech students interested
                     in improving their writing, communication and design skills. If you are interested in any of the following, consider joining the Technique.
                 </p>
-                    <ul className='text-lg my-3 list-disc ml-8'>
-                        <li>
-                            <strong>Improving your writing skills:</strong> By joining the Technique, you will learn how to write articles for a range of different 
-                            sections including News, Opinions, Life, Entertainment and Sports. In addition, you will learn how to interview sources and improve your skills 
-                            to analyze information and ask the right questions.
-                        </li>
-                        <li>
-                            <strong>Sales opportunities:</strong> As part of the business team, you can hone your salesmanship by selling ads for the paper. Sharpening 
-                            your sales skills can help you become a better marketer or manager in your professional career.
-                        </li>
-                        <li>
-                            <strong>Design skills:</strong> The Technique maintains two mediums of publication — both print and online formats. If you're interested in 
-                            graphic design, you'll have the opportunity to work with section editors to help design the paper layout on a weekly basis, which will help you 
-                            expand your graphic design portfolio.
-                        </li>
-                        <li>
-                            <strong>Photography:</strong> Our staff is responsible for taking photos for the paper. Lessons on topics such as shooting sports, portraits, 
-                            landscapes, etc., are held by fellow students.
-                        </li>
-                    </ul>
+                <ul className='text-lg my-3 list-disc ml-8'>
+                    <li>
+                        <strong>Improving your writing skills:</strong> By joining the Technique, you will learn how to write articles for a range of different
+                        sections including News, Opinions, Life, Entertainment and Sports. In addition, you will learn how to interview sources and improve your skills
+                        to analyze information and ask the right questions.
+                    </li>
+                    <li>
+                        <strong>Sales opportunities:</strong> As part of the business team, you can hone your salesmanship by selling ads for the paper. Sharpening
+                        your sales skills can help you become a better marketer or manager in your professional career.
+                    </li>
+                    <li>
+                        <strong>Design skills:</strong> The Technique maintains two mediums of publication — both print and online formats. If you're interested in 
+                        graphic design, you'll have the opportunity to work with section editors to help design the paper layout on a weekly basis, which will help you 
+                        expand your graphic design portfolio.
+                    </li>
+                    <li>
+                        <strong>Photography:</strong> Our staff is responsible for taking photos for the paper. Lessons on topics such as shooting sports, portraits,
+                        landscapes, etc., are held by fellow students.
+                    </li>
+                </ul>
 
                 <p className='text-lg'>
                     General Body Meetings are held weekly on Tuesdays at 7:00 p.m. in the Student Center in room 2150 (Student Media suite).
                 </p>
                 <p className='text-lg mt-3'>
-                    Please join the 
-                    <a href=" https://join.slack.com/t/techniquestaf-lba4588/shared_invite/zt-2p2rgiqtx-95XC_o1P~x2mOLihFDFA~Q" 
-                        target="_blank" 
+                    Please join the
+                    <a href=" https://join.slack.com/t/techniquestaf-lba4588/shared_invite/zt-2p2rgiqtx-95XC_o1P~x2mOLihFDFA~Q"
+                        target="_blank"
                         rel="noopener noreferrer"
-                        className='text-nique-light-blue hover:text-nique-blue-hover'> <u>Slack Channel</u> </a> 
+                        className='text-nique-light-blue hover:text-nique-blue-hover'> <u>Slack Channel</u> </a>
                     if interested!
                 </p>
             </div>
         </>
-    )
+    );
 }
 
 export default About;

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import articleService from '../services/articleService';
-import publicationService from '../services/publicationService';
+import { getPublications } from '../services/publicationService';
 import { ArticleDocument } from '../types/article';
 import { Publication, formatPublicationDate } from '../utils/dateFormat';
 import { FaFacebook, FaXTwitter, FaInstagram, FaTiktok, FaLinkedin } from "react-icons/fa6";
@@ -21,19 +21,21 @@ function About() {
             setIsLoading(true);
 
             try {
-                // fetching articles and publication dates at the same time
-                const [recentArticlesData, publicationsData] = await Promise.all([
-                    articleService.fetchRecentArticles(7, 'published', controller.signal),
-                    publicationService.getPublications()
-                ]);
-
-                if (!isMounted) return;
-
-                setRecentArticles(recentArticlesData || []);
-                setPublications(publicationsData || []);
+                const recentArticlesData = await articleService.fetchRecentArticles(7, 'published', controller.signal);
+                if (isMounted) {
+                    setRecentArticles(recentArticlesData || []);
+                }
             } catch (err) {
-                if (!isMounted) return;
-                console.error('Error loading About page data:', err);
+                console.error('Failed to fetch recent articles:', err);
+            }
+
+            try {
+                const publicationsData = await getPublications();
+                if (isMounted) {
+                    setPublications(publicationsData || []);
+                }
+            } catch (err) {
+                console.error('Failed to fetch publication dates:', err);
             } finally {
                 if (isMounted) {
                     setIsLoading(false);
@@ -173,7 +175,7 @@ function About() {
                 </p>
                 <p className='text-lg mt-3'>
                     Please join the
-                    <a href=" https://join.slack.com/t/techniquestaf-lba4588/shared_invite/zt-2p2rgiqtx-95XC_o1P~x2mOLihFDFA~Q"
+                    <a href="https://join.slack.com/t/techniquestaf-lba4588/shared_invite/zt-2p2rgiqtx-95XC_o1P~x2mOLihFDFA~Q"
                         target="_blank"
                         rel="noopener noreferrer"
                         className='text-nique-light-blue hover:text-nique-blue-hover'> <u>Slack Channel</u> </a>

--- a/frontend/src/pages/SubmitAd.tsx
+++ b/frontend/src/pages/SubmitAd.tsx
@@ -2,7 +2,7 @@ import Navbar from '../components/Navbar';
 import { useState, useEffect, Suspense, lazy } from 'react';
 import MediaKit from '../assets/media-kit-2024.pdf';
 import Spinner from '../components/Spinner';
-import publicationService from '../services/publicationService';
+import { getPublications } from '../services/publicationService';
 import { Publication, formatPublicationDate } from '../utils/dateFormat';
 
 const PDFViewer = lazy(() => import('../components/PDFViewer'));
@@ -39,12 +39,12 @@ function SubmitAd() {
 
         const loadPublications = async () => {
             try {
-                const data = await publicationService.getPublications();
+                const data = await getPublications();
                 if (isMounted) {
                     setPublications(data || []);
                 }
             } catch (err) {
-                console.error('Error loading publication dates:', err);
+                console.error('Failed to load publication dates for Submit Ad page:', err);
             }
         };
 
@@ -103,6 +103,7 @@ function SubmitAd() {
                     </Suspense>
                 )}
 
+                {/* Price Plans */}
                 <div className="my-4">
                     <h4 className="text-2xl font-bold mb-2 text-nique-blue mt-6">Price Plans</h4>
 
@@ -119,6 +120,7 @@ function SubmitAd() {
                     </div>
                 </div>
 
+                {/* Upcoming Print Dates Section */}
                 {publications.length > 0 && (
                     <div className="my-6">
                         <h4 className="text-2xl font-bold mb-2 text-nique-blue mt-6">Upcoming Print Dates</h4>
@@ -132,6 +134,7 @@ function SubmitAd() {
                     </div>
                 )}
 
+                {/* Need Help Section */}
                 <div className="my-4">
                     <h4 className="text-2xl font-bold mb-2 text-nique-blue mt-6">Need help?</h4>
                     <a href="/contact" className="block">

--- a/frontend/src/pages/SubmitAd.tsx
+++ b/frontend/src/pages/SubmitAd.tsx
@@ -1,7 +1,9 @@
 import Navbar from '../components/Navbar';
-import { useState, Suspense, lazy } from 'react';
+import { useState, useEffect, Suspense, lazy } from 'react';
 import MediaKit from '../assets/media-kit-2024.pdf';
 import Spinner from '../components/Spinner';
+import publicationService from '../services/publicationService';
+import { Publication, formatPublicationDate } from '../utils/dateFormat';
 
 const PDFViewer = lazy(() => import('../components/PDFViewer'));
 
@@ -26,14 +28,36 @@ const adPricePlans = [
         price: "$35-$420",
         link: "https://epay.gatech.edu/C20793_ustores/web/product_detail.jsp?PRODUCTID=5820"
     }
-]    
+];
 
 function SubmitAd() {
     const [showPDF, setShowPDF] = useState(false);
+    const [publications, setPublications] = useState<Publication[]>([]);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const loadPublications = async () => {
+            try {
+                const data = await publicationService.getPublications();
+                if (isMounted) {
+                    setPublications(data || []);
+                }
+            } catch (err) {
+                console.error('Error loading publication dates:', err);
+            }
+        };
+
+        loadPublications();
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
 
     const onClick = () => {
         setShowPDF(!showPDF);
-    }
+    };
 
     return (
         <>
@@ -55,9 +79,9 @@ function SubmitAd() {
                         <div className="border rounded-md border-nique-blue py-12 px-20">
                             <h4 className="text-4xl font-bold mb-4 text-nique-blue">2.</h4>
                             <h4 className="text-xl font-bold text-nique-blue">Submit online</h4>
-                            <p className="mb-4">View the price plans below and place an order for your ad.</p> 
-                            <a href="https://epay.gatech.edu/C20793_ustores/web/store_main.jsp?STOREID=13&FROMQRCODE=true" 
-                                target="_blank" 
+                            <p className="mb-4">View the price plans below and place an order for your ad.</p>
+                            <a href="https://epay.gatech.edu/C20793_ustores/web/store_main.jsp?STOREID=13&FROMQRCODE=true"
+                                target="_blank"
                                 rel="noopener noreferrer"
                             >
                                 <button className='bg-nique-blue hover:bg-nique-blue-hover rounded-md text-white px-2 py-1'>
@@ -70,7 +94,7 @@ function SubmitAd() {
 
                 {showPDF && (
                     <Suspense fallback={<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-xs p-4"><Spinner /></div>}>
-                        <PDFViewer 
+                        <PDFViewer
                             isOpen={showPDF}
                             onClose={() => setShowPDF(false)}
                             pdfFile={MediaKit}
@@ -83,17 +107,30 @@ function SubmitAd() {
                     <h4 className="text-2xl font-bold mb-2 text-nique-blue mt-6">Price Plans</h4>
 
                     <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 justify-between radius-md">
-                        {adPricePlans.map((ad) => (
-                            <a href={ad.link} target="_blank" rel="noopener noreferrer">
-                            <div className="border rounded-md border-nique-blue aspect-square p-4 lg:p-6 flex flex-col justify-center hover:shadow-xl hover:bg-nique-blue-hover/4 transition duration-300">
-                                <h4 className="text-4xl font-bold text-nique-blue text-center">{ad.price}</h4>
-                                <h6 className="text-sm mb-4 text-nique-blue text-center">(price depends on color & size)</h6>
-                                <p className="text-center">{ad.type}</p>
-                             </div>
+                        {adPricePlans.map((ad, idx) => (
+                            <a key={idx} href={ad.link} target="_blank" rel="noopener noreferrer">
+                                <div className="border rounded-md border-nique-blue aspect-square p-4 lg:p-6 flex flex-col justify-center hover:shadow-xl hover:bg-nique-blue-hover/4 transition duration-300">
+                                    <h4 className="text-4xl font-bold text-nique-blue text-center">{ad.price}</h4>
+                                    <h6 className="text-sm mb-4 text-nique-blue text-center">(price depends on color & size)</h6>
+                                    <p className="text-center">{ad.type}</p>
+                                </div>
                             </a>
                         ))}
                     </div>
                 </div>
+
+                {publications.length > 0 && (
+                    <div className="my-6">
+                        <h4 className="text-2xl font-bold mb-2 text-nique-blue mt-6">Upcoming Print Dates</h4>
+                        <ul className="list-disc ml-8 text-lg">
+                            {publications.map((pub) => (
+                                <li key={pub._id} className="mt-1">
+                                    {formatPublicationDate(pub)}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
 
                 <div className="my-4">
                     <h4 className="text-2xl font-bold mb-2 text-nique-blue mt-6">Need help?</h4>
@@ -106,6 +143,6 @@ function SubmitAd() {
             </div>
         </>
     );
-};
+}
 
 export default SubmitAd;

--- a/frontend/src/services/publicationService.ts
+++ b/frontend/src/services/publicationService.ts
@@ -11,3 +11,7 @@ export const getPublications = async (): Promise<Publication[]> => {
   const response = await apiClient.get('/publications');
   return response.data;
 };
+
+export default {
+  getPublications,
+};

--- a/frontend/src/services/publicationService.ts
+++ b/frontend/src/services/publicationService.ts
@@ -1,0 +1,13 @@
+import apiClient from './apiClient';
+
+export interface Publication {
+  _id: string;
+  issueName: string;
+  issueType: string;
+  publishDate: string;
+}
+
+export const getPublications = async (): Promise<Publication[]> => {
+  const response = await apiClient.get('/publications');
+  return response.data;
+};

--- a/frontend/src/utils/dateFormat.ts
+++ b/frontend/src/utils/dateFormat.ts
@@ -1,3 +1,6 @@
+import type { Publication } from '../services/publicationService';
+export type { Publication };
+
 export const formatPublicationDate = (pub: Publication): string => {
   const date = new Date(pub.publishDate);
   

--- a/frontend/src/utils/dateFormat.ts
+++ b/frontend/src/utils/dateFormat.ts
@@ -1,0 +1,8 @@
+export const formatPublicationDate = (pub: Publication): string => {
+  const date = new Date(pub.publishDate);
+  
+  const month = date.toLocaleDateString('en-US', { month: 'long', timeZone: 'UTC' });
+  const day = date.toLocaleDateString('en-US', { day: 'numeric', timeZone: 'UTC' });
+  
+  return `${month}, ${day} (${pub.issueName})`;
+};


### PR DESCRIPTION
## Overview
Added fetching and rendering for upcoming publication print dates on both the "Submit Ad" and "About" pages.

## Changes Made
- Created `publicationService` to fetch publication dates from the backend endpoint (`/api/publications`)
- Created a `dateFormat` util to format publication dates consistently
- Integrated dynamic print dates list into `frontend/src/pages/SubmitAd.tsx` and `frontend/src/pages/About.tsx`

## Testing
- Verified locally that publication dates returned from the backend render accurately under the **Upcoming Print Dates** section