### PR TITLE
feat: replace spinner loading screen with landing page placeholder

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Suspense, lazy } from "react";
 // import ReactGA from 'react-ga4';
 import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
 import Spinner from "./components/Spinner";
+import HomeSkeleton from "./components/HomeSkeleton";
 import Footer from "./components/Footer";
 import Seo from "./components/Seo";
 
@@ -85,17 +86,27 @@ function RouteSeo() {
   );
 }
 
+function RouteFallback() {
+  const location = useLocation();
+
+  if (location.pathname === "/") {
+    return <HomeSkeleton />;
+  }
+
+  return (
+    <div className="flex justify-center items-center h-screen">
+      <Spinner />
+    </div>
+  );
+}
+
 function App() {
   return (
     <Router>
       <RouteSeo />
       <div className="App min-h-screen flex flex-col">
         <div className="flex-1">
-          <Suspense fallback={
-              <div className="flex justify-center items-center h-screen">
-                  <Spinner />
-              </div>
-          }>
+          <Suspense fallback={<RouteFallback />}>
               <Routes>
             {/* Public routes */}
             <Route path="/" element={<Home />} />

--- a/frontend/src/components/HomeSkeleton.tsx
+++ b/frontend/src/components/HomeSkeleton.tsx
@@ -1,0 +1,110 @@
+import Navbar from './Navbar';
+import { Categories } from '../types/categories';
+
+// Stand-in for a single ArticleBlock. Mirrors ArticleBlock's rounded corners
+// and height contract so the placeholder grid lines up with the real one.
+function BlockPlaceholder({ height, className = '' }: { height?: string; className?: string }) {
+    return (
+        <div
+            className={`w-full rounded-md bg-gray-200 max-h-[50vh] md:max-h-none motion-safe:animate-pulse ${className}`}
+            style={height ? { height } : undefined}
+        />
+    );
+}
+
+// Category headings are static text on Home, so render the real ones here.
+function CategoryHeading({ name }: { name: string }) {
+    return <h4 className="font-bold mb-2 text-2xl text-nique-blue">{name}</h4>;
+}
+
+/**
+ * Placeholder screen shown while the landing page loads. It mirrors Home's
+ * grid so the layout is already in place when the articles arrive, rather than
+ * the whole page snapping in from a centered spinner.
+ */
+function HomeSkeleton() {
+    return (
+        <>
+            <Navbar />
+            <div
+                role="status"
+                aria-busy="true"
+                aria-label="Loading articles"
+                className='max-w-[95%] md:max-w-[80%] m-auto p-5 grid grid-cols-1 md:grid-cols-[auto_30%] lg:grid-cols-[auto_25%] gap-5'
+            >
+                <div className='w-full'>
+                    {/* Main */}
+                    <div className='grid gap-5 grid-cols-1 lg:grid-cols-[30%_auto] lg:grid-rows-4 w-full h-[80vh]'>
+                        <div className='flex flex-col gap-4 order-last lg:order-first lg:row-span-4'>
+                            {Array.from({ length: 4 }).map((_, index) => (
+                                <BlockPlaceholder key={index} className='flex-1' />
+                            ))}
+                        </div>
+                        <div className='flex flex-col gap-4 row-span-4 h-full'>
+                            <BlockPlaceholder className='flex-1' />
+                            <BlockPlaceholder className='flex-1' />
+                        </div>
+                    </div>
+
+                    <hr className='my-3' />
+
+                    {/* Categories */}
+                    <CategoryHeading name={Categories.LIFE} />
+                    <div className='grid grid-cols-2 md:grid-cols-[48%_auto] gap-4'>
+                        <div className='w-full'>
+                            <BlockPlaceholder height='396px' />
+                        </div>
+                        <div className='flex flex-col gap-4 w-full'>
+                            <BlockPlaceholder height='190px' />
+                            <BlockPlaceholder height='190px' />
+                        </div>
+                    </div>
+
+                    <hr className='my-3' />
+
+                    <CategoryHeading name={Categories.NEWS} />
+                    <div className='grid grid-cols-3 sm:flex-row gap-4'>
+                        {Array.from({ length: 3 }).map((_, index) => (
+                            <BlockPlaceholder key={index} height='200px' />
+                        ))}
+                    </div>
+
+                    <hr className='my-3' />
+
+                    <CategoryHeading name={Categories.ENTERTAINMENT} />
+                    <div className='grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4'>
+                        {Array.from({ length: 8 }).map((_, index) => (
+                            <BlockPlaceholder key={index} height='230px' />
+                        ))}
+                    </div>
+
+                    <hr className='my-3' />
+
+                    <CategoryHeading name={Categories.SPORTS} />
+                    <div className='grid gap-4 grid-cols-1 sm:grid-cols-4'>
+                        <div className='sm:col-span-2'>
+                            <BlockPlaceholder height='396px' />
+                        </div>
+                        <div className='sm:col-span-2 grid gap-4 grid-cols-1 md:grid-cols-2'>
+                            {Array.from({ length: 4 }).map((_, index) => (
+                                <BlockPlaceholder key={index} height='190px' />
+                            ))}
+                        </div>
+                    </div>
+                </div>
+
+                {/* Sidebar */}
+                <div className='flex flex-col gap-4'>
+                    <BlockPlaceholder height='420px' />
+                    <div className='flex flex-col gap-4'>
+                        {Array.from({ length: 4 }).map((_, index) => (
+                            <BlockPlaceholder key={index} height='90px' />
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default HomeSkeleton;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -8,7 +8,7 @@ import SideWidget from '../components/SideWidget';
 import SideArticle from '../components/SideArticle';
 import { Categories } from '../types/categories';
 import Navbar from '../components/Navbar';
-import Spinner from '../components/Spinner';
+import HomeSkeleton from '../components/HomeSkeleton';
 import InfiniteScrollModule from '../components/InfiniteScrollModule';
 import { getArticleId, getArticleTimestamp } from '../utils/articlePresentation';
 import spotifyService from '../services/spotifyService';
@@ -193,11 +193,7 @@ function Home() {
     }, [opinionArticles]);
 
     if (isLoading) {
-        return (
-            <div className="flex justify-center items-center h-screen">
-                <Spinner/>
-            </div>
-        );
+        return <HomeSkeleton />;
     }
 
     if (error) {


### PR DESCRIPTION
Closes #38.

The landing page showed a centered spinner while articles loaded, so the page snapped into place all at once. Replace it with a placeholder screen that mirrors Home's grid, so the layout is already there when the articles arrive and the site reads as loading faster.

HomeSkeleton renders the real Navbar and category headings (both static, no data) and stands in for each ArticleBlock with a pulsing box at the same height, so the placeholder lines up with the real grid.

Used in both places the landing page showed a spinner: Home's own fetch state, and App's route-level Suspense fallback via RouteFallback, which keeps the spinner for every other route.